### PR TITLE
fix: maxHeight increase for the poup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ditto-insurance/react-timely",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Load ditto timely scheduler from any react site",
   "author": "joinditto",
   "license": "MIT",

--- a/src/components/TimelyModal.tsx
+++ b/src/components/TimelyModal.tsx
@@ -30,7 +30,7 @@ const customModalStylesMd = {
     minWidth: '900px',
     maxWidth: '1060px',
     height: '100%',
-    maxHeight: '620px',
+    maxHeight: '680px',
     padding: 0,
     background: 'transparent',
     border: 'none',


### PR DESCRIPTION
This pull request includes a version bump and a minor UI adjustment to the modal component. The most important changes are:

Version update:

* Bumped the package version in `package.json` from `1.1.0` to `1.1.1` to reflect the new changes.

UI improvement:

* Increased the `maxHeight` of the modal in `TimelyModal.tsx` from `620px` to `680px` to allow for more content display.