### PR TITLE
add click ID fields to Utm type for ad platform tracking

### DIFF
--- a/src/timely.tsx
+++ b/src/timely.tsx
@@ -31,6 +31,16 @@ export type Utm = Optional<{
   ref: string
   referral_url: string
   referral_code: string
+  gclid: string
+  gbraid: string
+  wbraid: string
+  dclid: string
+  msclkid: string
+  fbclid: string
+  ttclid: string
+  li_fat_id: string
+  ScCid: string
+  [key: string]: string
 }>
 
 export type IframeTitle = string


### PR DESCRIPTION
## Summary
- Adds 9 ad platform click ID fields (gclid, fbclid, msclkid, gbraid, wbraid, dclid, ttclid, li_fat_id, ScCid) to the Utm type
- Adds index signature `[key: string]: string` for future-proofing
- No logic changes — formUrl() already iterates all keys in the utm object

## Related PRs
- joinditto/dma — passes click IDs via loadTimely()
- joinditto/timely-frontend#95 — receives click IDs in utmKeys

## Test plan
- [ ] Build the plugin successfully
- [ ] Verify DMA can pass click IDs to the Timely iframe without TypeScript errors